### PR TITLE
Circshift does not throw error for a 0-dim array

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1147,6 +1147,7 @@ See also [`circshift`](@ref).
     dest === src && throw(ArgumentError("dest and src must be separate arrays"))
     inds = axes(src)
     axes(dest) == inds || throw(ArgumentError("indices of src and dest must match (got $inds and $(axes(dest)))"))
+    any(size(src) .== 0) && return dest
     _circshift!(dest, (), src, (), inds, fill_to_length(shiftamt, 0, Val(N)))
 end
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -748,6 +748,12 @@ end
     @test res === dst == [5 6 4; 2 3 1]
     res = circshift!(dst, src, (3.0, 2.0))
     @test res === dst == [5 6 4; 2 3 1]
+
+    # https://github.com/JuliaLang/julia/issues/41402
+    src = Float64[]
+    @test circshift(src, 1) == src
+    src = zeros(Bool, (4,0))
+    @test circshift(src, 1) == src
 end
 
 @testset "circcopy" begin


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/41402

Return the `dest` array if any dimension of `src` is 0. Because of the 0-dimension, no value is stored in the array and `dest==src`. 